### PR TITLE
Version lock Ruby to 2.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.6'
+
 gem 'jekyll', '3.7.2'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,5 +78,8 @@ DEPENDENCIES
   jekyll-seo-tag (= 2.4.0)
   jekyll-sitemap (= 1.2.0)
 
+RUBY VERSION
+   ruby 2.3.6p384
+
 BUNDLED WITH
-   1.16.0
+   1.16.6


### PR DESCRIPTION
Someone approve this if Netlify build passes.