### PR TITLE
Add password protection to Netlify PR deploys

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+Changes proposed in this pull request:
+
+*
+*
+*
+
+---
+
+The credentials to view the Netlify deploy is the following:
+
+* **username**: crabigator
+* **password**: googlebegone

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base = "/"
+  publish = "_site/"
+  command = "jekyll build && cp netlify_headers _site/_headers"
+
+[context.production]
+  command = "jekyll build"

--- a/netlify_headers
+++ b/netlify_headers
@@ -1,0 +1,2 @@
+/*
+  Basic-Auth: crabigator:googlebegone


### PR DESCRIPTION
* Adds password protection on Netlify PR deploys. This is to block robots from crawling preview sites
* Add credentials to PR template