### PR TITLE
Fix typo — per year, not per month

### DIFF
--- a/_posts/2018-11-25-subscription-plans.md
+++ b/_posts/2018-11-25-subscription-plans.md
@@ -18,7 +18,7 @@ A monthly subscription is $9/month and is a recurring charge. That means it will
 
 ## Annual Subscription
 
-An annual subscription is $89/month and is a recurring charge. That's like getting two months free compared to paying for a monthly subscription for an entire year!
+An annual subscription is $89/year and is a recurring charge. That's like getting two months free compared to paying for a monthly subscription for an entire year!
 
 This plan automatically charges your card each year and renews itself ([unless it's canceled](/account-and-membership/payment-and-billing/cancel-subscription/)).
 


### PR DESCRIPTION
Fixes #15

Changes proposed in this pull request:

* Update subscription plans copy to correctly state pricing **per year**, not **per month**
---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
