### PR TITLE
Fix/srs remove outdated links

### DIFF
--- a/_posts/2018-11-25-srs.md
+++ b/_posts/2018-11-25-srs.md
@@ -7,7 +7,7 @@ description:
 type: Document
 ---
 
-If you've read through the [Onboarding Series](https://knowledge.wanikani.com/getting-started/how-wanikani-works/) (hint, hint), then you've seen us going on about something called the **SRS.** But what the heck is an SRS?
+If you've read through the [Onboarding Series](/getting-started/how-wanikani-works/) (hint, hint), then you've seen us going on about something called the **SRS.** But what the heck is an SRS?
 
 Stay awhile and listen, young durtle, and all will be revealed.
 

--- a/_posts/2018-11-25-srs.md
+++ b/_posts/2018-11-25-srs.md
@@ -7,7 +7,7 @@ description:
 type: Document
 ---
 
-If you've read the [FAQ](https://www.wanikani.com/faq) or the [WaniKani Guide](https://www.wanikani.com/guide) (hint, hint), then you've seen us going on about something called the **SRS.** But what the heck is an SRS?
+If you've read through the [Onboarding Series](https://knowledge.wanikani.com/getting-started/how-wanikani-works/) (hint, hint), then you've seen us going on about something called the **SRS.** But what the heck is an SRS?
 
 Stay awhile and listen, young durtle, and all will be revealed.
 


### PR DESCRIPTION
Changes proposed in this pull request:

*Removed outdated references to the old FAQ and Guide and replaced with link to beginning of the Onboarding Series instead.
*
*

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
