### PR TITLE
Display hero search regardless of media

### DIFF
--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -125,7 +125,7 @@ header {
 }
 
 .hero_search {
-	display: none;
+	// display: none;
 	text-align: center;
 	flex: 0 0 100%;
 	padding: 60px 0 30px 0;


### PR DESCRIPTION
Closes #24 

Changes proposed in this pull request:

* Display hero search regardless of media

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
