### PR TITLE
Set Environment for Production Builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@
   command = "jekyll build && cp netlify_headers _site/_headers"
 
 [context.production]
-  command = "jekyll build"
+  command = "JEKYLL_ENV=production jekyll build"


### PR DESCRIPTION
Changes proposed in this pull request:

* Run production builds in the production context. Mainly addresses the lack of Google Analytics on the pages because of [the conditional in the default template](https://github.com/tofugu/wanikani-knowledgebase/blob/master/_layouts/default.html#L14) needing a production environment.

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone