### PR TITLE
Updated Information for SRS stages

### DIFF
--- a/_posts/2018-11-25-srs-stages.md
+++ b/_posts/2018-11-25-srs-stages.md
@@ -63,7 +63,7 @@ Apprentice 1 → **4 hours** → Apprentice 2 \\
 Apprentice 2 → **8 hours** → Apprentice 3 \\
 Apprentice 3 → **1 day** → Apprentice 4 \\
 Apprentice 4 → **2 days** → Guru 1 \\
-Guru 1 → **4 days** → Guru 2 \\
+Guru 1 → **1 week** → Guru 2 \\
 Guru 2 → **2 weeks** → Master \\
 Master → **1 month** → Enlightened \\
 Enlightened → **4 months** → Burned


### PR DESCRIPTION
I updated the SRS stages description to account for an inaccuracy. I changed the amount of time from Guru 1 to Guru 2 from 4 days to 1 week.

Changes proposed in this pull request:

* Guru 1 > Guru 2 now says 1 week instead of 4 days


---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
