### PR TITLE
test adding sorting based on frontmatter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,8 @@ exclude:
 
 collections:
   sets:
+  posts:
+    sort_by: set-order
 
 
 jekyll-archives:


### PR DESCRIPTION
Changes proposed in this pull request:

* this is a test to try and order posts based on frontmatter

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
