### PR TITLE
Unify naming - to WaniKani Knowledge Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WaniKani Knowledge Base
+# WaniKani Knowledge Guide
 
-Knowledge base for [WaniKani](https://www.wanikani.com). Browse through the [production build](https://knowledge.wanikani.com/).
+Knowledge Guide for [WaniKani](https://www.wanikani.com). Browse through the [production build](https://knowledge.wanikani.com/).
 
 Platform and template forked from [CloudCannon's base-jekyll-template](https://github.com/CloudCannon/base-jekyll-template). Review their [README](https://github.com/CloudCannon/base-jekyll-template) for developing and editing information.
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
 					{% include navigation.html %}
 				</section>
 				<section class="hero_search">
-					<h1>WaniKani User Guide</h1>
+					<h1>WaniKani Knowledge Guide</h1>
 					<p>Everything you need to know about waiting a really long time for your precious reviews</p>
 					{% include search.html %}
 				</section>


### PR DESCRIPTION
Changes proposed in this pull request:

* Change User guide to Knowledge Guide on homepage and README

![image](https://user-images.githubusercontent.com/3673236/94491859-df226a80-019d-11eb-8f79-4f2719518fef.png)


---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
