### PR TITLE
Fix typo "ream", should be "read"

### DIFF
--- a/_posts/2018-11-25-common-mistakes.md
+++ b/_posts/2018-11-25-common-mistakes.md
@@ -25,7 +25,7 @@ Lots of kanji have multiple readings, like 大 (たい, だい) or 力 (りき, 
 
 Most likely, you are putting in a big や, ゆ, or よ instead of a small one. The difference is big, and it’s important to get these correct. For example, じゆう means “freedom,” so if you wrote that in instead of じゅう you would be saying something completely different.
 
-[Ream more about small characters and how to type them.](/japanese/small_characters/)
+[Read more about small characters and how to type them.](/japanese/small_characters/)
 
 ## Verbs
 


### PR DESCRIPTION
Fixed a typo on the Common Mistakes page with "read".

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
