### PR TITLE
Update to Ruby 2.7.4 and Bundler 2.2.26

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.6'
+ruby '2.7.4'
 
 gem 'jekyll', '3.7.2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.7.4'
-
 gem 'jekyll', '3.7.2'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,5 @@ DEPENDENCIES
   jekyll-seo-tag (= 2.4.0)
   jekyll-sitemap (= 1.2.0)
 
-RUBY VERSION
-   ruby 2.7.4p191
-
 BUNDLED WITH
    2.2.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ DEPENDENCIES
   jekyll-sitemap (= 1.2.0)
 
 RUBY VERSION
-   ruby 2.3.6p384
+   ruby 2.7.4p191
 
 BUNDLED WITH
-   1.16.6
+   2.2.26


### PR DESCRIPTION
Fixes https://github.com/tofugu/wanikani-knowledgebase/issues/52

The required Ruby is very old. When installing the old version of Ruby, it attempts to install an old version OpenSSL which breaks the install. This version of OpenSSL has been broken for a while.

Changes proposed in this pull request:

* Upgrade to Ruby 2.7.4
* Upgrade to Bundler 2.2.26

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
