### PR TITLE
Remove Ruby version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.3.6'
-
 gem 'jekyll', '3.7.2'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,5 @@ DEPENDENCIES
   jekyll-seo-tag (= 2.4.0)
   jekyll-sitemap (= 1.2.0)
 
-RUBY VERSION
-   ruby 2.3.6p384
-
 BUNDLED WITH
    1.16.6


### PR DESCRIPTION
Fixes https://github.com/tofugu/wanikani-knowledgebase/issues/52

No need to require a specific Ruby version. Reverting the inclusion back to follow the parent project's pattern of not specifying the Ruby version.

Changes proposed in this pull request:

* Remove requiring a specific Ruby version.

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
