### PR TITLE
Bump Script Version to 0.2.0

### DIFF
--- a/_posts/2021-08-18-script-compatibility-mode.md
+++ b/_posts/2021-08-18-script-compatibility-mode.md
@@ -7,21 +7,21 @@ description:
 type: Document
 ---
 
-Changes that are affected by the Script Compatibility Mode setting are tracked here.
-Scripts can check WaniKani's version by checking `window.WaniKani.version` to match against this list.
+Changes that are affected by the Script Compatibility Mode setting are tracked here. Scripts can check WaniKani's version by checking `window.WaniKani.version` to match against this list.
 
-**v0.1.1 (August 30, 2021)** 
+**v0.2.0 (September 20, 2021)**
+- **Compatibility Mode Off**: Notes in lessons are now rendered with React and submit with `fetch`.
+
+**v0.1.1 (August 30, 2021)**
 - **Both Modes**: Fixed issue where network requests did not work in some cases on IE11 because `fetch` needed a polyfill
 - **Compatibility Mode Off**: Review queues are fetched with `fetch` and not `$.ajax` or `$.getJSON`
 
-**v0.1.0 (August 25, 2021)** Main bundles of lessons and reviews are now tied to the script compatibility setting. 
+**v0.1.0 (August 25, 2021)** Main bundles of lessons and reviews are now tied to the script compatibility setting.
 - **Compatibility Mode On**: script tags serve lesson-legacy and review-legacy (plus hash in the filename)
 - **Compatibility Mode Off**: script tags serve lessson and review (plus hash in the filename)
 
-This is intended to prevent accidental breaking changes that might affect scripts. Future updates will specify whether legacy versions are affected (for example, 
-if a bug fix is applied to both legacy and non-legacy).
+This is intended to prevent accidental breaking changes that might affect scripts. Future updates will specify whether legacy versions are affected (for example, if a bug fix is applied to both legacy and non-legacy).
 
-**v0.0.1 (August 18, 2021)** Lesson tabs (ex. Kanji Composition, Meaning, Reading, etc.) are now rendered with React. Previously tabs were written to the DOM and just hidden and displayed with CSS.
-With React tabs that are not visible are removed from the DOM. Scripts that modify tabs have to wait for React to finish rendering the tab.
+**v0.0.1 (August 18, 2021)** Lesson tabs (ex. Kanji Composition, Meaning, Reading, etc.) are now rendered with React. Previously tabs were written to the DOM and just hidden and displayed with CSS. With React tabs that are not visible are removed from the DOM. Scripts that modify tabs have to wait for React to finish rendering the tab.
 
 


### PR DESCRIPTION
Outlines the changes for the next significant script release.

**Note**: We shouldn’t merge this until tofugu/wanikani#2803 is on production.

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: googlebegone
