### PR TITLE
Script Compatibility Mode v0.5.0: Submit review progress with fetch and retry with $.ajax on failure

### DIFF
--- a/_posts/2021-08-18-script-compatibility-mode.md
+++ b/_posts/2021-08-18-script-compatibility-mode.md
@@ -11,6 +11,9 @@ Changes that are affected by the Script Compatibility Mode setting are tracked h
 
 Subscribe to the [mailing list](https://tofugu.us1.list-manage.com/subscribe?u=b7f2114d74e3cac96344f797c&id=8b79442fb1) get notified when this page is updated. Make sure to check **UserScript Affecting Changes**.
 
+**v0.5.0 (October 19, 2021)**
+- **Compatibility Mode Off**: Submissions to /json/progress are first attempted with fetch and then fall back to $.ajax when unsuccessful
+
 **v0.4.0 (October 13, 2021)**
 - **Compatibility Mode Off**: Unread lessons are tracked through jStorage under `l/unreadIndices` instead of the presence of `read` class on batch-list items
 


### PR DESCRIPTION
- **Compatibility Mode Off**: Submissions to /json/progress are first attempted with fetch and then fall back to $.ajax when unsuccessful